### PR TITLE
Add names of targets in tar_plans to environment

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,12 +1,23 @@
 #' Collect all targets and lists of targets in the environment
-all_targets <- function(env = parent.env(environment()), type = "tar_target") {
+all_targets <- function(env = parent.env(environment()), type = "tar_target", add_list_names = TRUE) {
+  
+  # Function to determine if an object is a type (a target), or a list on only that type
   rfn <- function(obj) inherits(obj, type) || (is.list(obj) && all(vapply(obj, rfn, logical(1))))
+  # Get the names everything in the environment (e.g. sourced in the _targets file)
   objs <- ls(env)
   out <- list()
+  
   for(o in objs) {
-    obj <- get(o, envir = env)
-    if (rfn(obj)) {
-      out[[length(out) + 1]] <- obj
+    obj <- get(o, envir = env) # Get each top-level object in turn
+    if (rfn(obj)) { # For targets and lists of targets
+      out[[length(out) + 1]] <- obj # Add them to the output
+      
+      # If the object is a list of targets, add a vector of those names to the environment
+      # So that one can call `tar_make(list_name)` to make all the targets in that list
+      if(add_list_names && is.list(obj)) {
+        target_names <- vapply(obj, \(x) x$settings$name, character(1))
+        assign(o, target_names, envir = env)
+      }
     }
   }
   return(out)


### PR DESCRIPTION
This tweak to `all_targets()` adds the feature that, if the environment has lists of targets, such as those created by `tar_plan()`, it will assign a vector of those targets' names to the environment, using the name of the list object.  This overwrites the list objects, but that's OK, because we have already collected them as part of the output.  This means, for each list of targets, one can call any targets function with the name of the list, e.g, `tar_make(static_targets)`, or `tar_visnetwork(targets_only = TRUE, static_targets)`.  It will not work with things like `tar_load()`, which do not actually run `_targets.R`.